### PR TITLE
feat(validation): forbid '|' in ticketId/deviceId

### DIFF
--- a/functions/tests/test_issue_token.py
+++ b/functions/tests/test_issue_token.py
@@ -172,3 +172,25 @@ def test_error_missing_signing_secret(monkeypatch):
     body = parse_body(resp)
     assert resp.status_code == 500
     assert body["error"] == "Server misconfiguration"
+
+
+def test_error_ticket_id_contains_pipe(monkeypatch):
+    # 目的: ticketId に '|' が含まれる場合バリデーションエラーとなることを確認
+    # 期待値: status_code == 400, メッセージに 'ticketId' と '|' が含まれる
+    monkeypatch.setenv("SIGNING_SECRET", "secret")
+    req = DummyReq({"ticketId": "ev|ent", "deviceId": "d1"})
+    resp = issue.main(req)
+    body = parse_body(resp)
+    assert resp.status_code == 400
+    assert "ticketId" in body["error"] and "|" in body["error"]
+
+
+def test_error_device_id_contains_pipe(monkeypatch):
+    # 目的: deviceId に '|' が含まれる場合バリデーションエラーとなることを確認
+    # 期待値: status_code == 400, メッセージに 'deviceId' と '|' が含まれる
+    monkeypatch.setenv("SIGNING_SECRET", "secret")
+    req = DummyReq({"ticketId": "t1", "deviceId": "dev|01"})
+    resp = issue.main(req)
+    body = parse_body(resp)
+    assert resp.status_code == 400
+    assert "deviceId" in body["error"] and "|" in body["error"]


### PR DESCRIPTION
## Summary
Add validation to reject pipe character '|' in ticketId/deviceId to keep signature message unambiguous.

## Changes
- Validation: reject '|' in ticketId / deviceId
- Added two negative tests (pipe in ticketId / deviceId)
- README: Added prohibition note and verification sample
- Switched to azure.functions.HttpResponse for correctness

## Motivation
'|' is used as a delimiter in the signed message "ticketId|deviceId|startAt|ttl|nonce". Allowing it could introduce ambiguity if future parsing logic splits by delimiter.

## Testing
All tests pass (18): TTL clamp, deterministic signature, signature matrix, error cases, new pipe rejection tests.

## Next (Optional)
- Add signature format version prefix (e.g. v1|)
- Introduce verify endpoint
- Separate dev/prod requirements
