### PR TITLE
chore: add .gitignore for iOS/Xcode artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+### macOS
+.DS_Store
+
+### Xcode user-specific
+ios-demo/**/xcuserdata/
+ios-demo/**/*.xcuserstate
+
+### Swift Package Manager (future-proof)
+.build/
+
+### Derived Data (if path added later)
+DerivedData/
+
+### Misc
+*.swp
+*.tmp


### PR DESCRIPTION
Add initial .gitignore covering macOS, Xcode user data, build artifacts, and temp files.\n\nThis prevents noisy user-specific changes (xcuserdata, *.xcuserstate) and preps for future SwiftPM usage.\n\nNo functional code changes.